### PR TITLE
Made it compatible with Python 3.12 and above

### DIFF
--- a/coursera_helper/coursera_dl.py
+++ b/coursera_helper/coursera_dl.py
@@ -49,7 +49,7 @@ import re
 import time
 import shutil
 
-from distutils.version import LooseVersion as V
+from packaging.version import Version as V 
 
 
 # Test versions of some critical modules.

--- a/requirements.txt
+++ b/requirements.txt
@@ -8,3 +8,4 @@ configargparse>=0.12.0
 attrs==18.1.0
 playwright>=1.38.0
 browser_cookie3>=0.19.1
+packaging>=24.1


### PR DESCRIPTION
## Proposed changes

This pull request updates the version comparison method from `distutils.version.LooseVersion` to `packaging.version.Version`. This change is necessary because `distutils` is deprecated in Python 3.10 and removed in Python 3.12. The `packaging` library provides a more robust and maintained solution for version comparison.

Additionally, I've added `packaging>=24.1` to the `requirements.txt` file to ensure the new dependency is properly installed.

## Types of changes

What types of changes does your code introduce?
_Put an `x` in the boxes that apply_

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating
the PR. If you're unsure about any of them, don't hesitate to ask. We're here
to help! This is simply a reminder of what we are going to look for before
merging your code._

- [x] I have read the [CONTRIBUTING](/CONTRIBUTING.md) doc
- [x] I agree to contribute my changes under the project's [LICENSE](/LICENSE)
- [x] I have checked that the unit tests pass locally with my changes
- [x] I have checked the style of the new code (lint/pep).
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)

## Further comments

This change is a proactive measure to ensure the project's compatibility with Python versions 3.12 and above and to use a more maintained library for version comparison. The `packaging` library is widely used and recommended for version parsing and comparison tasks.
